### PR TITLE
Fix path in cron

### DIFF
--- a/resources/cron-inkystock-5m
+++ b/resources/cron-inkystock-5m
@@ -1,1 +1,1 @@
-*/5     * * * *     username      cd /homeusername/inkystock && ./run.sh
+*/5     * * * *     username      cd /home/username/inkystock && ./run.sh


### PR DESCRIPTION
Added a missing forward slash in the path to the inkystock directory