### PR TITLE
Automatically configure display size and color.

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -30,16 +30,21 @@ provider = CoinGecko
 #  sqlite:////absolute/path/to/file.db
 database = sqlite:///data/inkystock.db
 
-# The width of the e-ink display in pixels. This is configured for the original Inky pHAT (212x104),
-# but the 2020 models have a higher resolution (250x122). Update these values if you have the newer model.
-# display_width_pixels = 212
+# The width of the e-ink display in pixels (or auto).
+# This is automatically configured, if you want to override auto configuration, do so here.
+# display_width_pixels = auto
 
-# The height of the e-ink display in pixels. (See above)
-# display_height_pixels = 104
+# The height of the e-ink display in pixels (or auto).
+# This is automatically configured, if you want to override auto configuration, do so here.
+# display_height_pixels = auto
 
 # The physical diagonal display size, in inches, of the screen. This is used to scale the size of the chart,
 # as it uses matplotlib which is designed for print dimensions.
 # display_diagonal_inches = 2.13
+
+# The color model of the Inky pHAT display.
+# This is detected automatically, but can be set to black, yellow, or red.
+# color = auto
 
 # Rotate the display. Unit is degrees, so to display upside down, set to 180.
 # rotate_display = 0

--- a/inkystock/chart.py
+++ b/inkystock/chart.py
@@ -92,13 +92,13 @@ class Chart(Element):
         if self._cache:
             return self._cache
 
+        if self.config.main.color in ['red', 'yellow']:
+            palette = Palette.color()
+        else:
+            palette = Palette.black_and_white()
+
         with io.BytesIO() as f:
             self.fig.savefig(f, dpi=self.dpi(), pad_inches=0, bbox_inches='tight')
             chart = Image.open(f).convert('RGB')
-            if self.config.main.color in ['red', 'yellow']:
-                palette = Palette.color()
-            else:
-                palette = Palette.black_and_white()
-            # Quantize (change to dither=1 if you want dithering)
-            self._cache = chart.quantize(palette=palette, dither=0)
+            self._cache = chart.quantize(palette=palette)
             return self._cache

--- a/inkystock/chart.py
+++ b/inkystock/chart.py
@@ -63,7 +63,7 @@ class Chart(Element):
         """
         diagonal_resolution_px = sqrt(pow(self.config.main.display_width_pixels, 2) +
                                       pow(self.config.main.display_height_pixels, 2))
-        return float(int(diagonal_resolution_px / self.config.main.display_diagonal_inches))
+        return diagonal_resolution_px / self.config.main.display_diagonal_inches
 
     def size(self):
         return self.render().size
@@ -94,11 +94,13 @@ class Chart(Element):
 
         if self.config.main.color in ['red', 'yellow']:
             palette = Palette.color()
+            num_colors = 3
         else:
             palette = Palette.black_and_white()
+            num_colors = 2
 
         with io.BytesIO() as f:
             self.fig.savefig(f, dpi=self.dpi(), pad_inches=0, bbox_inches='tight')
             chart = Image.open(f).convert('RGB')
-            self._cache = chart.quantize(palette=palette)
+            self._cache = chart.quantize(colors=num_colors, palette=palette, dither=Image.Dither.NONE)
             return self._cache

--- a/inkystock/config.py
+++ b/inkystock/config.py
@@ -1,8 +1,8 @@
 import os
 from configparser import ConfigParser
-from typing import List, Optional
-
+from typing import List, Optional, Union
 from pydantic import BaseModel, validator, HttpUrl
+from inky.auto import auto
 
 
 class ConfigurationException(ValueError):
@@ -15,11 +15,33 @@ class MainConfig(BaseModel):
     stock: str = ""
     crypto: str = "BTC"
     provider: str
-    display_width_pixels: int = 212
-    display_height_pixels: int = 104
+    display_width_pixels: Union[int,str] = 'auto'
+    display_height_pixels: Union[int,str] = 'auto'
     display_diagonal_inches: float = 2.13
     rotate_display: int = 0
     loglevel: str = "INFO"
+    color: str = 'auto'
+
+    @validator('display_width_pixels', pre=True, always=True)
+    def auto_display_width(cls, v):
+        if not v or v == 'auto':
+            display = auto()
+            return display.resolution[0]
+        return v
+
+    @validator('display_height_pixels', pre=True, always=True)
+    def auto_display_height(cls, v):
+        if not v or v == 'auto':
+            display = auto()
+            return display.resolution[1]
+        return v
+
+    @validator('color', pre=True, always=True)
+    def auto_color(cls, v):
+        if not v or v == 'auto':
+            display = auto()
+            return display.colour
+        return v
 
     @validator('currency')
     def currency_is_upper(cls, v):

--- a/inkystock/paint.py
+++ b/inkystock/paint.py
@@ -33,8 +33,8 @@ class PaletteData:
     Create palette. Must contain 768 integer values
     via @rferrese @ https://github.com/pimoroni/inky/issues/10#issuecomment-742273715
     """
-    BLACK_AND_WHITE = PALETTE_BLACK_AND_WHITE + [0] * (768 - len(PALETTE_BLACK_AND_WHITE))
-    COLOR = PALETTE_COLOR + [0] * (768 - len(PALETTE_COLOR))
+    BLACK_AND_WHITE = PALETTE_BLACK_AND_WHITE + [0, 0, 0] * 254
+    COLOR = PALETTE_COLOR + [0, 0, 0] * 253
 
 
 class Palette:

--- a/inkystock/paint.py
+++ b/inkystock/paint.py
@@ -17,9 +17,44 @@ from inkystock.layout import LayoutList, Container, Layout, Border
 log = logging.getLogger("inkystock")
 
 
+PALETTE_BLACK_AND_WHITE = [
+    255, 255, 255,
+    0, 0, 0,
+]
+PALETTE_COLOR = [
+    255, 255, 255,
+    0, 0, 0,
+    255, 0, 0
+]
+
+
+class PaletteData:
+    """
+    Create palette. Must contain 768 integer values
+    via @rferrese @ https://github.com/pimoroni/inky/issues/10#issuecomment-742273715
+    """
+    BLACK_AND_WHITE = PALETTE_BLACK_AND_WHITE + [0] * (768 - len(PALETTE_BLACK_AND_WHITE))
+    COLOR = PALETTE_COLOR + [0] * (768 - len(PALETTE_COLOR))
+
+
+class Palette:
+    """
+    Helper class for creating palettes to inject into image objects
+    """
+    def black_and_white():
+        palette = PILImage.new('P', (1,1))
+        palette.putpalette(PaletteData.BLACK_AND_WHITE)
+        return palette
+
+    def color():
+        palette = PILImage.new('P', (1,1))
+        palette.putpalette(PaletteData.COLOR)
+        return palette
+
+
 class Color:
-    BLACK = 0
-    WHITE = 1
+    BLACK = 1
+    WHITE = 0
 
 
 class Image(Element):
@@ -34,10 +69,6 @@ class Image(Element):
 
     @abc.abstractmethod
     def rotate(self, degrees):
-        pass
-
-    @abc.abstractmethod
-    def invert(self):
         pass
 
     @abc.abstractmethod
@@ -71,17 +102,6 @@ class PillowImage(Image):
     def rotate(self, degrees):
         log.debug(f"Rotating image {degrees} degrees")
         self.image = self.image.rotate(degrees)
-        return self
-
-    def invert(self):
-        log.debug("Inverting image colours")
-        inverted = PILImage.new('1', self.image.size)
-        remapped = []
-        pxmap = {0: 2, 1: 0, 2: 0, 255: 0}
-        for px in self.image.getdata():
-            remapped.append(pxmap[px])
-        inverted.putdata(remapped)
-        self.image = inverted
         return self
 
     def border(self, border: Border):
@@ -164,11 +184,25 @@ class Painter(abc.ABC):
 
 class Pillow(Painter):
 
+    def __init__(self, config):
+        self.config = config
+
+    def canvas(self, size):
+        if self.config.main.color in ['red', 'yellow']:
+            palette = PaletteData.COLOR
+        else:
+            palette = PaletteData.BLACK_AND_WHITE
+        image = PILImage.new('P', size, Color.WHITE)
+        image.putpalette(palette)
+        return image
+
     def new(self, size: Tuple[int, int]):
-        return PillowImage(PILImage.new('1', size, Color.WHITE))
+        canvas = self.canvas(size)
+        return PillowImage(canvas)
 
     def from_file(self, path):
-        return PillowImage(PILImage.open(path))
+        img = PILImage.open(path)
+        return PillowImage(img)
 
     def text(self, text, font: str, font_size: int) -> Text:
         """
@@ -188,7 +222,7 @@ class Pillow(Painter):
         height = bbox[3]  # have to ignore bbox[1] because it produces cropped text
         size = (width, height)
         log.debug(f"Bounding box for {text}: {bbox}, size: {size}")
-        canvas = PILImage.new('1', size, Color.WHITE)
+        canvas = self.canvas(size)
         draw = PILDraw.Draw(canvas)
 
         # Draw the text to the temporary canvas.
@@ -209,13 +243,13 @@ class Pillow(Painter):
         return poly.rotate(rotate)
 
     def line(self, size: Tuple[int, int]):
-        canvas = PILImage.new('1', size, Color.WHITE)
+        canvas = self.canvas(size)
         draw = PILDraw.Draw(canvas)
         draw.line([(0, 0), (size[0], 0)], fill=Color.BLACK, width=size[1])
         return PillowImage(canvas)
 
     def polygon(self, size: Tuple[int, int], points: Sequence) -> Image:
-        canvas = PILImage.new('1', size, Color.WHITE)
+        canvas = self.canvas(size)
         draw = PILDraw.Draw(canvas)
 
         draw.polygon(points, fill=Color.BLACK)
@@ -223,10 +257,14 @@ class Pillow(Painter):
 
     def display(self, image: PillowImage):
         board = auto()
-        board.set_image(image.invert().render())
+        board.set_image(image.render())
         board.show()
 
     def paint(self, size: Tuple[int, int], layout: LayoutList):
+        if self.config.main.color in ['red', 'yellow']:
+            palette = Palette.color()
+        else:
+            palette = Palette.black_and_white()
         canvas = self.new(size).render()
         for position, element in layout:
             if type(element) is Container:
@@ -237,6 +275,10 @@ class Pillow(Painter):
                 image = element.render()
                 log.info(f"Rendering {element} to canvas, size: {image.size} position: {position}")
                 # Use alpha blending where applicable (e.g., mascots)
-                mask = image if image.mode != '1' else None
+                mask = None
+                if image.mode == 'RGBA':
+                    mask = image.split()[3]
+                    image = image.convert('RGB')
+                    image = image.quantize(palette=palette, dither=0)
                 canvas.paste(image, (position.x, position.y), mask=mask)
         return PillowImage(canvas)

--- a/main.py
+++ b/main.py
@@ -35,7 +35,11 @@ def main():
     args = parser.parse_args()
 
     config = Config(env_vars=env_vars, path=args.config)
+
     log = setup_logging(config.main.loglevel)
+
+    log.info(f"Configured resolution: {config.main.display_width_pixels}x{config.main.display_height_pixels}")
+    log.info(f"Configured color: {config.main.color}")
 
     db = Database(config)
 
@@ -65,7 +69,7 @@ def main():
     recent = db.recent()
 
     # the painter is responsible for turning the layout we're specifying into pixels
-    painter = Pillow()
+    painter = Pillow(config)
 
     # The details (elements, layout, etc) of UI components are specified in ui.py.
     # This hopefully makes the relationship between the data and its layout clearer.


### PR DESCRIPTION
Will hopefully address issues where newer Inky displays produced a blank image (e.g. #10)

I got a hold of a newer colour display, though I don't have a new black and white one. Still need to test this branch against my original B&W model before merging. Some tweaking still needed for the chart to get the text displaying more crisply – matplotlib does not make this easy 😅 

Added bonus is that the trend line in the chart will now be displayed in colour ✨:

![IMG_8810](https://github.com/duggan/inkystock/assets/143117/2d609ddb-38d0-4f42-80c1-e0dd715c579c)