### PR TITLE
CoinGecko requires an API key, include configuration and docs for it.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ Full install last tested on **27th March, 2024**.
 
 The hardware is fortunately very simple, and all just slots together, no soldering, etc. Not too many parts either:
 
- * [InkyPHAT eInk display](https://shop.pimoroni.com/products/inky-phat?variant=12549254938707)
- * [Raspberry Pi Zero WH](https://shop.pimoroni.com/products/raspberry-pi-zero-wh-with-pre-soldered-header) or Raspberry Pi Zero 2 (with headers).
- * [microSD card](https://shop.pimoroni.com/products/noobs-32gb-microsd-card-3-1?variant=31703694245971)  
- * Micro-B USB Cable (to connect to power supply)
- * A Pretty Case (Optional)
+- [InkyPHAT eInk display](https://shop.pimoroni.com/products/inky-phat?variant=12549254938707)
+- [Raspberry Pi Zero WH](https://shop.pimoroni.com/products/raspberry-pi-zero-wh-with-pre-soldered-header) or Raspberry Pi Zero 2 (with headers).
+- [microSD card](https://shop.pimoroni.com/products/noobs-32gb-microsd-card-3-1?variant=31703694245971)
+- Micro-B USB Cable (to connect to power supply)
+- A Pretty Case (Optional)
 
 You can buy off the shelf Raspberry Pi Zero cases. The official one looks like it would work, and the InkyPHAT tutorial uses a [Pibow](https://shop.pimoroni.com/products/pibow-zero-w) case. If you have access to a 3D printer, [this is the case I've used (pictured above)](https://www.thingiverse.com/thing:4054844).
 
@@ -35,12 +35,14 @@ Also, it's best to start with a freshly flashed OS; should help avoid any myster
 Assuming you're using the default `pi` user on Raspbian (Buster), SSH to the pi:
 
 Enable SPI and I2C:
+
 ```
 sudo raspi-config nonint do_spi 0
 sudo raspi-config nonint do_i2c 0
 ```
 
 Install dependencies and app:
+
 ```bash
 wget -O inkystock.zip https://github.com/duggan/inkystock/archive/main.zip
 unzip inkystock.zip && mv inkystock-main inkystock
@@ -49,7 +51,9 @@ sudo make deps
 make install
 ```
 
-Now you'll want to modify `config.ini` to suit, adding IEX Cloud API key information if you want to use it for stocks.
+Now you'll want to modify `config.ini` to suit, adding IEX Cloud API key information if you want to use it for stocks, or CoinGecko for crypto.
+
+**Note**: as of **February 2024**, a CoinGecko Demo API key is required, which you can get for free by using the ["Create Demo Account" on their pricing page](https://www.coingecko.com/en/api/pricing).
 
 You can perform a test run by executing `./run.sh`. If it's set up correctly, you should see your screen updated within 10 seconds or so. If not, the error messages will hopefully be helpful enough to point you in the right direction.
 
@@ -60,6 +64,7 @@ If you see an error like the following:
 then it may be worth [trying the inky "one line installer" from the Pimoroni tutorial.](https://learn.pimoroni.com/tutorial/sandyj/getting-started-with-inky-phat)
 
 When you're happy it's working, you can install a cron job to update the screen every 5 minutes:
+
 ```bash
 sudo make cron.5m
 ```
@@ -110,26 +115,34 @@ At present, the only supported stock provider is IEX Cloud. You can register for
 ## UI
 
 ### Status Bar
+
 Shows the coin, currency, and date/time the screen was last updated.
+
 ### Ticker Bar
+
 Shows recent price changes.
+
 ### Headline
+
 Shows the most recent price, its change since the last trading day, and a cat with a suitable level of concern/satisfaction depending on the direction.
+
 ### Chart
+
 Displaying the last 7 days of activity.
 
 ## Customizing
+
 You can fairly easily customize some parts of the UI in `config.ini`; changing the mascot ( goodbye, pixelcat :< ), the fonts, etc.
 
 For example:
 
-| Happening           | Cat                                                       |
-|---------------------|-----------------------------------------------------------|
-| Price goes up       | ![happy cat](./resources/pixelcat/pixelcat_cool.png)      |
-| Price goes down     | ![worried cat](./resources/pixelcat/pixelcat_worried.png) |
+| Happening                   | Cat                                                         |
+| --------------------------- | ----------------------------------------------------------- |
+| Price goes up               | ![happy cat](./resources/pixelcat/pixelcat_cool.png)        |
+| Price goes down             | ![worried cat](./resources/pixelcat/pixelcat_worried.png)   |
 | Market closed / no movement | ![sleeping cat](./resources/pixelcat/pixelcat_sleeping.png) |
 
-In crypto-land, however, *the market never closes*, so you'll probably never see sleeping cat. No rest for the proletariat!
+In crypto-land, however, _the market never closes_, so you'll probably never see sleeping cat. No rest for the proletariat!
 
 These are controlled via these values in `config.ini`:
 
@@ -150,16 +163,14 @@ For example, a simple swap out of stocks for COVID-19 vaccination data (see [res
 
 ![UI with Ireland COVID-19 Vaccination Rate](./resources/docs/vaccine.png)
 
-
-
 ## Credits
 
-* [Getting Started with Inky pHAT](https://learn.pimoroni.com/tutorial/sandyj/getting-started-with-inky-phat) is a good introduction to the basics.
-* The 04B pixel fonts included are sourced from http://www.04.jp.org/
-* [The Cozette font was developed by slavfox.](https://github.com/slavfox/Cozette)
-* [Matt Brubeck's in-depth guide on writing a layout engine in Rust](https://limpet.net/mbrubeck/2014/08/08/toy-layout-engine-1.html) was a great reference guide.
-* [José Fernando Costa's blog post on text sizing with PIL/Pillow](https://levelup.gitconnected.com/how-to-properly-calculate-text-size-in-pil-images-17a2cc6f51fd) was helpful with some head scratchers.
-* Inspiration from [Pwnagotchi](https://github.com/evilsocket/pwnagotchi) and [inky-cryptochart](https://github.com/DurandA/inky-cryptochart).
+- [Getting Started with Inky pHAT](https://learn.pimoroni.com/tutorial/sandyj/getting-started-with-inky-phat) is a good introduction to the basics.
+- The 04B pixel fonts included are sourced from http://www.04.jp.org/
+- [The Cozette font was developed by slavfox.](https://github.com/slavfox/Cozette)
+- [Matt Brubeck's in-depth guide on writing a layout engine in Rust](https://limpet.net/mbrubeck/2014/08/08/toy-layout-engine-1.html) was a great reference guide.
+- [José Fernando Costa's blog post on text sizing with PIL/Pillow](https://levelup.gitconnected.com/how-to-properly-calculate-text-size-in-pil-images-17a2cc6f51fd) was helpful with some head scratchers.
+- Inspiration from [Pwnagotchi](https://github.com/evilsocket/pwnagotchi) and [inky-cryptochart](https://github.com/DurandA/inky-cryptochart).
 
 ## Developing
 
@@ -247,12 +258,12 @@ As "hello worlds" go it's quite verbose, but it works fine when putting lots of 
 
 A stock provider must provide both a current price quote, and historical prices.
 
-If adding a third-party client, it should not pull in pandas or other large dependencies. I'd much prefer an implementation that just uses *requests* to interact with the relevant API endpoints.
+If adding a third-party client, it should not pull in pandas or other large dependencies. I'd much prefer an implementation that just uses _requests_ to interact with the relevant API endpoints.
 
 Providers tried/rejected:
 
-* **Alpha Vantage**: only supports historical data
-* **Coindesk**: only supports Bitcoin
+- **Alpha Vantage**: only supports historical data
+- **Coindesk**: only supports Bitcoin
 
 ## Disclaimer
 

--- a/config.ini
+++ b/config.ini
@@ -75,6 +75,14 @@ database = sqlite:///data/inkystock.db
 # token = ""
 
 ##
+# CoinGecko (Cryptocurrency data provider)
+# Since February 2024, a CoinGecko Demo API key is required, which you can get for free
+# by using the "Create Demo Account" button on their pricing page.
+# See: https://www.coingecko.com/en/api/pricing
+[CoinGecko]
+# api_key = ""
+
+##
 # Mascot
 ##
 [Mascot]

--- a/inkystock/config.py
+++ b/inkystock/config.py
@@ -14,7 +14,7 @@ class MainConfig(BaseModel):
     database = "sqlite:////tmp/inkystock.db"
     stock: str = ""
     crypto: str = "BTC"
-    provider: str
+    provider: str = "CoinGecko"
     display_width_pixels: Union[int,str] = 'auto'
     display_height_pixels: Union[int,str] = 'auto'
     display_diagonal_inches: float = 2.13
@@ -94,6 +94,25 @@ class IEXConfig(BaseModel):
     token: str
     endpoint: HttpUrl = "https://cloud.iexapis.com/stable"
 
+    @validator('token', 'endpoint')
+    def strip_quotes(cls, v):
+        if v and "'" in v:
+            return v.strip("'")
+        if v and '"' in v:
+            return v.strip('"')
+        return v
+
+class CoinGecko(BaseModel):
+    api_key: str
+
+    @validator('api_key')
+    def strip_quotes(cls, v):
+        if v and "'" in v:
+            return v.strip("'")
+        if v and '"' in v:
+            return v.strip('"')
+        return v
+
 
 class OutputConfig(BaseModel):
     screen: str = "inky"
@@ -132,3 +151,8 @@ class Config:
         self.iex = IEXConfig(token="")
         if self.main.provider == 'IEX':
             self.iex = IEXConfig(**self.__config['IEX'])
+
+        # CoinGecko provider configuration
+        self.coingecko = CoinGecko(api_key="")
+        if self.main.provider == 'CoinGecko':
+            self.coingecko = CoinGecko(**self.__config['CoinGecko'])

--- a/inkystock/stocks/coingecko.py
+++ b/inkystock/stocks/coingecko.py
@@ -1,12 +1,41 @@
 import logging
 from datetime import datetime, timedelta
 
+import requests
+from requests.adapters import HTTPAdapter
+from requests.packages.urllib3.util.retry import Retry
 from pycoingecko import CoinGeckoAPI
 from inkystock.config import Config
 from inkystock.stocks.base import Stock, Point, Series
 
 
 log = logging.getLogger("inkystock")
+
+
+class CustomCoinGeckoAPI(CoinGeckoAPI):
+    def __init__(self, demo_api_key: str = '', retries=5):
+        super().__init__(api_key='', retries=retries)  # Call the superclass initializer
+        self.demo_api_key = demo_api_key
+        if demo_api_key:
+            self.session.headers.update({'x_cg_demo_api_key': demo_api_key})
+
+    def __api_url_params(self, api_url, params, api_url_has_params=False):
+        # If using a demo version of CoinGecko, inject key in every call
+        if self.demo_api_key:
+            params['x_cg_demo_api_key'] = self.demo_api_key
+        else:
+            # If not using demo key, fall back to the original behavior
+            if self.api_key:
+                params['x_cg_pro_api_key'] = self.api_key
+
+        if params:
+            api_url += '&' if api_url_has_params else '?'
+            for key, value in params.items():
+                if isinstance(value, bool):
+                    value = str(value).lower()
+                api_url += f"{key}={value}&"
+            api_url = api_url[:-1]
+        return api_url
 
 
 class CoinGecko(Stock):
@@ -16,13 +45,16 @@ class CoinGecko(Stock):
     def __init__(self, config: Config):
         super().__init__(config)
         self.PROVIDER_CURRENCY = self.config.main.currency  # CoinGecko supports currency conversion natively
-        self.cg = CoinGeckoAPI()
+        self.cg = CustomCoinGeckoAPI(demo_api_key=config.coingecko.api_key)
 
     def symbol_to_id(self):
         symbol = self.config.main.crypto.lower()
+        if symbol == 'btc':
+            return 'bitcoin'
         coins = self.cg.get_coins_list()
         for coin in coins:
             if coin['symbol'] == symbol:
+                log.info(f"Mapped crypto sumbol {self.config.main.crypto} to CoinGecko ID {coin['id']}")
                 return coin['id']
         raise ValueError(f"Could not map {self.config.main.crypto} to a CoinGecko ID")
 


### PR DESCRIPTION
Override CoinGecko API client init so can set demo key with demo API base url

Also include a manual override for converting BTC to the internal CoinGecko symbol for it as the symbols appear to be non-unique.

Note: if you get an error about missing historical data when running `./run.sh`,  you might need to delete the cache database at `data/inkystock.db` due to cached incorrect data. If you know what you're doing it's an SQLite database and you can preserve historical data while clearing out specifically incorrect entries. I haven't done this since the data isn't important to me.